### PR TITLE
feat: add basic input field #117 :sparkles:

### DIFF
--- a/src/components/input/input.test.tsx
+++ b/src/components/input/input.test.tsx
@@ -1,7 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { InputProps, IonInput } from './input';
 import userEvent from '@testing-library/user-event';
-import { InputType } from '../../core/types/input';
+import { inputTypes } from '../../core/types/input';
 import React from 'react';
 
 const defaultInput: InputProps = {
@@ -42,13 +42,10 @@ describe('IonInput', () => {
   });
 
   describe('Alternatives cases', () => {
-    it.each(['password', 'number', 'email', 'text'] as InputType[])(
-      'should render input type %s',
-      (type) => {
-        sut({ ...defaultInput, type: type });
-        expect(getInput()).toHaveAttribute('type', type);
-      }
-    );
+    it.each(inputTypes)('should render input type %s', (type) => {
+      sut({ ...defaultInput, type: type });
+      expect(getInput()).toHaveAttribute('type', type);
+    });
 
     it('should render input disabled', () => {
       sut({ ...defaultInput, disabled: true });

--- a/src/components/input/input.test.tsx
+++ b/src/components/input/input.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/react';
+import { InputProps, IonInput } from './input';
+import userEvent from '@testing-library/user-event';
+import React from 'react';
+
+const defaultInput: InputProps = {
+  placeholder: 'Digite o seu nome',
+};
+
+const sut = (props: InputProps = defaultInput) => {
+  return render(<IonInput {...props} />);
+};
+
+const getInput = () => {
+  return screen.queryByPlaceholderText(defaultInput.placeholder!);
+};
+
+describe('IonInput', () => {
+  describe('Default', () => {
+    beforeEach(() => {
+      sut();
+    });
+
+    it('should render input with placeholder', () => {
+      expect(getInput()).toBeInTheDocument();
+    });
+
+    it('should render input enabled', () => {
+      expect(getInput()).toBeEnabled();
+    });
+
+    it('should render input text', () => {
+      expect(getInput()).toHaveAttribute('type', 'text');
+    });
+
+    it('should type value on input', async () => {
+      const textToType = 'Olá eu sou o Goku!';
+      await userEvent.type(getInput()!, textToType);
+      expect(getInput()).toHaveValue(textToType);
+    });
+  });
+
+  describe('Alternatives cases', () => {
+    it.each(['password', 'number'])(
+      'should render input type %s',
+      (type: string) => {
+        sut({ ...defaultInput, type: type });
+        expect(getInput()).toHaveAttribute('type', type);
+      }
+    );
+
+    it('should render input disabled', () => {
+      sut({ ...defaultInput, disabled: true });
+      expect(getInput()).toBeDisabled();
+    });
+  });
+});

--- a/src/components/input/input.test.tsx
+++ b/src/components/input/input.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react';
 import { InputProps, IonInput } from './input';
 import userEvent from '@testing-library/user-event';
+import { InputType } from '../../core/types/input';
 import React from 'react';
 
 const defaultInput: InputProps = {
@@ -41,9 +42,9 @@ describe('IonInput', () => {
   });
 
   describe('Alternatives cases', () => {
-    it.each(['password', 'number'])(
+    it.each(['password', 'number', 'email', 'text'] as InputType[])(
       'should render input type %s',
-      (type: string) => {
+      (type) => {
         sut({ ...defaultInput, type: type });
         expect(getInput()).toHaveAttribute('type', type);
       }

--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -1,9 +1,10 @@
+import { InputType } from '../../core/types/input';
 import { InputContainer, InputRow, InputStyles } from './styles';
 import React from 'react';
 
 export type InputProps = {
   placeholder?: string;
-  type?: string;
+  type?: InputType;
   disabled?: boolean;
 };
 

--- a/src/components/input/input.tsx
+++ b/src/components/input/input.tsx
@@ -1,0 +1,26 @@
+import { InputContainer, InputRow, InputStyles } from './styles';
+import React from 'react';
+
+export type InputProps = {
+  placeholder?: string;
+  type?: string;
+  disabled?: boolean;
+};
+
+export const IonInput = ({
+  placeholder,
+  type = 'text',
+  disabled = false,
+}: InputProps) => {
+  return (
+    <InputContainer>
+      <InputRow disabled={disabled}>
+        <InputStyles
+          type={type}
+          placeholder={placeholder}
+          disabled={disabled}
+        />
+      </InputRow>
+    </InputContainer>
+  );
+};

--- a/src/components/input/styles.ts
+++ b/src/components/input/styles.ts
@@ -1,0 +1,64 @@
+import stitches from '../../stitches.config';
+const { styled } = stitches;
+
+export const InputContainer = styled('div', {
+  display: 'flex',
+  lineHeight: '0',
+  width: '100%',
+});
+
+export const InputRow = styled('div', {
+  display: 'flex',
+  alignItems: 'center',
+  gap: '8px',
+  background: '$neutral1',
+  border: '1px solid $neutral5',
+  borderRadius: '8px',
+  padding: '8px 12px',
+  width: '100%',
+
+  variants: {
+    disabled: {
+      true: {
+        background: '$neutral2',
+        border: '1px solid $neutral4',
+        cursor: 'not-allowed',
+        outline: 'none',
+        color: '$neutral4',
+
+        '&:hover': {
+          borderColor: '$neutral4',
+        },
+
+        '::placeholder': {
+          color: '$neutral5',
+        },
+      },
+    },
+  },
+
+  '&:focus-within': {
+    borderColor: '$primary5',
+    outline: '2px solid',
+    outlineColor: '$primary2',
+  },
+
+  '&:hover': {
+    borderColor: '$primary4',
+  },
+});
+
+export const InputStyles = styled('input', {
+  border: 'none',
+  width: '100%',
+  outline: 'none',
+  color: '$neutral7',
+  background: '$neutral1',
+  fontSize: '14px',
+
+  '&[disabled]': {
+    background: '$neutral2',
+    cursor: 'not-allowed',
+    outline: 'none',
+  },
+});

--- a/src/core/types/input.ts
+++ b/src/core/types/input.ts
@@ -1,1 +1,2 @@
-export type InputType = 'password' | 'text' | 'number' | 'email';
+export const inputTypes = ['password', 'text', 'number', 'email'] as const;
+export type InputType = (typeof inputTypes)[number];

--- a/src/core/types/input.ts
+++ b/src/core/types/input.ts
@@ -1,0 +1,1 @@
+export type InputType = 'password' | 'text' | 'number' | 'email';

--- a/src/stories/input/input.stories.tsx
+++ b/src/stories/input/input.stories.tsx
@@ -22,6 +22,12 @@ Password.args = {
   type: 'password',
 };
 
+export const Number = Template.bind({});
+Number.args = {
+  placeholder: 'Digite sua idade',
+  type: 'number',
+};
+
 export const Disabled = Template.bind({});
 Disabled.args = {
   placeholder: 'Campo desabilitado',

--- a/src/stories/input/input.stories.tsx
+++ b/src/stories/input/input.stories.tsx
@@ -1,0 +1,29 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+
+import { InputProps, IonInput } from '../../components/input/input';
+
+export default {
+  title: 'Ion/Data Entry/Input',
+  component: IonInput,
+} as ComponentMeta<typeof IonInput>;
+
+const Template: ComponentStory<typeof IonInput> = (args: InputProps) => (
+  <IonInput {...args} />
+);
+
+export const Text = Template.bind({});
+Text.args = {
+  placeholder: 'Digite seu nome',
+};
+
+export const Password = Template.bind({});
+Password.args = {
+  placeholder: 'Digite sua senha',
+  type: 'password',
+};
+
+export const Disabled = Template.bind({});
+Disabled.args = {
+  placeholder: 'Campo desabilitado',
+  disabled: true,
+};


### PR DESCRIPTION
## Description

This add a input field with placeholder, disabled and type props.

## Screenshots

![image](https://user-images.githubusercontent.com/6165180/231792881-0aefcf97-f9f1-4f89-a635-aefb5c4aa784.png)

![image](https://user-images.githubusercontent.com/6165180/231793055-02600849-8ef9-4e56-b9c4-9514075659f9.png)

![image](https://user-images.githubusercontent.com/6165180/231793150-a384d5cb-45a6-4b21-b2a3-7245f50bcbf7.png)

## Compliance

- [x] I have verified that this change complies with our code and contribution policies.
- [x] I have verified that this change does not cause regressions and does not affect other parts of the code.
