### PR TITLE
refactor: ion badge with styled components

### DIFF
--- a/src/components/badge/badge.test.tsx
+++ b/src/components/badge/badge.test.tsx
@@ -1,8 +1,9 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 
-import { IonBadge, BadgeType, LabelType } from './badge';
-import { BadgeProps } from './badge';
+import theme from '@ion/styles/theme';
+import { renderWithTheme } from '../utils/test-utils';
+import { BadgeProps, BadgeType, IonBadge, LabelType } from './badge';
+import { typeColors } from './styles';
 
 const defaultBadge: BadgeProps = {
   label: 'Badge',
@@ -10,7 +11,7 @@ const defaultBadge: BadgeProps = {
 };
 
 const sut = (props: BadgeProps = defaultBadge) => {
-  return render(<IonBadge {...props} />);
+  return renderWithTheme(<IonBadge {...props} />);
 };
 
 const getBadge = () => {
@@ -28,7 +29,12 @@ describe('BadgeComponent', () => {
     });
 
     it('should render primary badge by default', async () => {
-      expect(getBadge().className).toContain('type-primary');
+      const { background, color } = typeColors(theme, 'primary');
+      expect(getBadge()).toHaveStyleRule('background-color', background);
+      expect(getBadge()).toHaveStyleRule(
+        'color',
+        color || theme.colors.neutral[1]
+      );
     });
   });
 
@@ -59,13 +65,18 @@ describe('BadgeComponent', () => {
       'primary',
       'secondary',
       'neutral',
-      'negative',
+      'danger',
     ];
     it.each(badgeTypes)(
       'should render badge %s type',
       async (type: BadgeType) => {
+        const { background, color } = typeColors(theme, type);
         sut({ ...defaultBadge, type: type });
-        expect(getBadge().className).toContain(`type-${type}`);
+        expect(getBadge()).toHaveStyleRule('background-color', background);
+        expect(getBadge()).toHaveStyleRule(
+          'color',
+          color || theme.colors.neutral[1]
+        );
       }
     );
   });

--- a/src/components/badge/badge.tsx
+++ b/src/components/badge/badge.tsx
@@ -1,16 +1,14 @@
-import React, { useState, useEffect } from 'react';
-import { BadgeStyles } from './styles';
-
-type StitchesBadgeProps = React.ComponentProps<typeof BadgeStyles>;
+import { useEffect, useState } from 'react';
+import { Badge } from './styles';
 
 export type LabelType = string | number;
 
-export type BadgeType = 'primary' | 'secondary' | 'neutral' | 'negative';
+export type BadgeType = 'primary' | 'secondary' | 'neutral' | 'danger';
 
 export type BadgeProps = {
   label: LabelType;
   type?: BadgeType;
-} & StitchesBadgeProps;
+};
 
 export const IonBadge = ({ label, type = 'primary' }: BadgeProps) => {
   const [badgeValue, setBadgeValue] = useState<LabelType>(0);
@@ -33,8 +31,8 @@ export const IonBadge = ({ label, type = 'primary' }: BadgeProps) => {
   }, [label]);
 
   return (
-    <BadgeStyles type={type} data-testid="ion-badge">
+    <Badge $type={type} data-testid='ion-badge'>
       {badgeValue}
-    </BadgeStyles>
+    </Badge>
   );
 };

--- a/src/components/badge/styles.ts
+++ b/src/components/badge/styles.ts
@@ -1,34 +1,58 @@
-import stitches from '../../stitches.config';
-import { spacing } from '../utils/spacing';
+import styled, { DefaultTheme, RuleSet, css } from 'styled-components';
+import { BadgeType } from './badge';
 
-const { styled } = stitches;
+type BadgeStylesProps = {
+  $type: BadgeType;
+};
 
-export const BadgeStyles = styled('span', {
-  fontWeight: '600',
-  fontSize: '12px',
-  lineHeight: '16px',
-  padding: `${spacing(0)} ${spacing(0.5)}`,
-  borderRadius: '50px',
-  cursor: 'default',
+type ColorByVariant = {
+  background: string;
+  color?: string;
+};
 
-  variants: {
-    type: {
-      primary: {
-        background: '$primaryColor',
-        color: '$neutral1',
-      },
-      secondary: {
-        background: '$secondaryColor',
-        color: '$primaryColor',
-      },
-      neutral: {
-        background: '$neutral4',
-        color: '$neutral8',
-      },
-      negative: {
-        background: '$negativeColor',
-        color: '$positive1',
-      },
+export const typeColors: (
+  theme: DefaultTheme,
+  type: BadgeType
+) => ColorByVariant = ({ colors }, type) =>
+  ({
+    primary: {
+      background: colors.main.primary,
     },
-  },
-});
+    secondary: {
+      background: colors.primary[1],
+      color: colors.main.primary,
+    },
+    neutral: {
+      background: colors.neutral[4],
+      color: colors.neutral[8],
+    },
+    danger: {
+      background: colors.main.negative,
+    },
+  }[type]);
+
+const type: (theme: DefaultTheme, type: BadgeType) => RuleSet<object> = (
+  theme,
+  type
+) => {
+  const { background, color } = typeColors(theme, type);
+
+  return css`
+    background-color: ${background};
+    color: ${color || theme.colors.neutral[1]};
+  `;
+};
+
+export const Badge = styled.span<BadgeStylesProps>`
+  ${({ theme, $type }) => css`
+    ${theme.font.size[12]};
+    font-weight: 600;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0 0.4rem;
+    border-radius: 50rem;
+    user-select: none;
+    ${type(theme, $type)};
+  `}
+`;

--- a/src/components/tab/tab.test.tsx
+++ b/src/components/tab/tab.test.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
+import { renderWithTheme } from '../utils/test-utils';
 import { IonTab, TabProps } from './tab';
 
 const clickEvent = jest.fn();
@@ -11,7 +11,7 @@ const defaultTab: TabProps = {
 };
 
 function sut(props: TabProps = defaultTab) {
-  render(<IonTab {...props} />);
+  renderWithTheme(<IonTab {...props} />);
 }
 
 const getTab = () => {

--- a/src/components/tab/tab.tsx
+++ b/src/components/tab/tab.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { BorderDirection } from '../../core/types/directions';
 import { SizeType } from '../../core/types/size';
-import { IonBadge, BadgeProps } from '../badge/badge';
+import { BadgeProps, IonBadge } from '../badge/badge';
 import { IonIcon } from '../icons/icons';
 import { iconType } from '../icons/svgs/icons';
 import { TabStyles } from './styles';
@@ -31,11 +31,12 @@ export const IonTab = ({
   handleClick,
   badge,
 }: TabProps) => {
-  const iconSize = {
-    sm: 16,
-    md: 20,
-    lg: 24,
-  };
+  const getIconSize = (size: TabSizes) =>
+    ({
+      sm: 16,
+      md: 20,
+      lg: 24,
+    }[size]);
 
   return (
     <>
@@ -45,10 +46,10 @@ export const IonTab = ({
         onClick={handleClick}
         selected={selected}
         disabled={disabled}
-        data-testid="ion-tab"
+        data-testid='ion-tab'
       >
         <div>
-          {icon && <IonIcon type={icon} size={iconSize[`${size}`]} />}
+          {icon && <IonIcon type={icon} size={getIconSize(size)} />}
           <span>{label}</span>
           {badge && <IonBadge label={badge.label} type={badge.type} />}
         </div>

--- a/src/components/tabGroup/tabGroup.test.tsx
+++ b/src/components/tabGroup/tabGroup.test.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { iconType } from '../icons/svgs/icons';
 import { TabProps } from '../tab/tab';
+import { renderWithTheme } from '../utils/test-utils';
 import { IonTabGroup, IonTabGroupProps, TabGroupSizes } from './tabGroup';
 
 const mockClick = jest.fn();
@@ -22,7 +22,7 @@ const mockProps: IonTabGroupProps = {
   handleSelectedTab: mockClick,
 };
 const sut = (props: IonTabGroupProps = mockProps) => {
-  render(<IonTabGroup {...props} />);
+  renderWithTheme(<IonTabGroup {...props} />);
 };
 
 const getTabGroup = () => screen.getByTestId('ion-tabGroup');

--- a/src/components/tag/tag.tsx
+++ b/src/components/tag/tag.tsx
@@ -1,13 +1,11 @@
-import React from 'react';
-
-import { TagStyle } from './styles';
 import { IonIcon } from '../icons/icons';
+import { TagStyle } from './styles';
 
-import { validateHexColor } from '../utils/validateHexColor';
-import ErrorBoundary from '../error/error-boundary';
 import { TagStatus } from '../../core/types/status';
+import ErrorBoundary from '../error/error-boundary';
 import { iconType } from '../icons/svgs/icons';
 import isValidLabel from '../utils/isValidLabel';
+import { validateHexColor } from '../utils/validateHexColor';
 
 export interface IonTagProps {
   outline?: boolean;
@@ -49,12 +47,12 @@ export const IonTag = ({
   outline = true,
 }: IonTagProps) => {
   if (!isValidLabel(label)) {
-    return <ErrorBoundary msg="Label cannot be empty" />;
+    return <ErrorBoundary msg='Label cannot be empty' />;
   }
 
   return (
     <TagStyle
-      data-testid="ion-tag"
+      data-testid='ion-tag'
       status={status}
       outline={outline}
       css={{ ...getColorObject(status, color) }}

--- a/src/stories/badge/badge.stories.tsx
+++ b/src/stories/badge/badge.stories.tsx
@@ -1,6 +1,6 @@
-import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
 
-import { IonBadge, BadgeProps } from '../../components/badge/badge';
+import { BadgeProps, IonBadge } from '../../components/badge/badge';
 
 export default {
   title: 'Ion/Data display/Badges',
@@ -18,34 +18,34 @@ StringLabel.args = {
 
 export const NumberLabel = Template.bind({});
 NumberLabel.args = {
-  label: '10',
+  label: 10,
 };
 
 export const BiggerValue = Template.bind({});
 BiggerValue.args = {
-  label: '100',
+  label: 100,
 };
 
 export const Primary = Template.bind({});
 Primary.args = {
-  label: 'Primary',
+  label: 'Badge',
   type: 'primary',
 };
 
 export const Secondary = Template.bind({});
 Secondary.args = {
-  label: 'Secondary',
+  label: 'Badge',
   type: 'secondary',
 };
 
 export const Neutral = Template.bind({});
 Neutral.args = {
-  label: 'Neutral',
+  label: 'Badge',
   type: 'neutral',
 };
 
-export const Negative = Template.bind({});
-Negative.args = {
-  label: 'Negative',
-  type: 'negative',
+export const Danger = Template.bind({});
+Danger.args = {
+  label: 'Badge',
+  type: 'danger',
 };


### PR DESCRIPTION
- Refactor ion badge to use styled components.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced theme-based styling and utility functions for rendering badges in the `BadgeComponent`.

- **Refactor**
	- Updated `BadgeType` enum value from `'negative'` to `'danger' in badge components.
	- Refactored styling logic in `BadgeStyles` to use a `typeColors` function for color variations.
	- Minor adjustments in `tag.tsx` for code cleanliness (reordering imports and updating string literals).
	- Renamed `Negative` story to `Danger` in badge stories for consistency.

- **Style**
	- Enhanced badge rendering with style rules for background and text color based on badge types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->